### PR TITLE
`raise NotImplemented()` should be `raise NotImplementedError()`

### DIFF
--- a/fmt/fmt.py
+++ b/fmt/fmt.py
@@ -45,7 +45,7 @@ def generate(nodes, namespace):
 
 class Node(object):
     def generate(self, ns):
-        raise NotImplemented()
+        raise NotImplementedError()
 
 
 class Text(Node):


### PR DESCRIPTION
https://docs.python.org/3/library/constants.html#NotImplemented
